### PR TITLE
Fix type inference error

### DIFF
--- a/smuggler-samples/smuggler-application/src/main/java/io/mironov/smuggler/application/SampleFragment.kt
+++ b/smuggler-samples/smuggler-application/src/main/java/io/mironov/smuggler/application/SampleFragment.kt
@@ -25,7 +25,7 @@ class SampleFragment : Fragment() {
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
 
-    val text = view.findViewById(R.id.text) as TextView
+    val text = view.findViewById<TextView>(R.id.text)
     val args = arguments.getParcelable<SampleArguments>("arguments")
 
     text.text = args.message.text


### PR DESCRIPTION
```
$ ./gradlew clean :smuggler-samples:smuggler-application:assembleRelease

e: $PROJECT_ROOT/smuggler-samples/smuggler-application/src/main/java/io/mironov/smuggler/application/SampleFragment.kt: (28, 21): Type inference failed: Not enough information to infer parameter T in fun <T : View!> findViewById(p0: Int): T!
Please specify it explicitly.
```