### PR TITLE
Update scripts and plugin dependencies to use latest Gradle configura…

### DIFF
--- a/smuggler-compiler/build.gradle
+++ b/smuggler-compiler/build.gradle
@@ -13,15 +13,15 @@ targetCompatibility = JavaVersion.VERSION_1_6
 sourceCompatibility = JavaVersion.VERSION_1_6
 
 dependencies {
-  compile "org.slf4j:slf4j-api:$slf4jVersion"
+  implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
-  compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
-  compile "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
+  implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+  implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
 
-  compile "org.ow2.asm:asm:$asmVersion"
-  compile "org.ow2.asm:asm-commons:$asmVersion"
+  implementation "org.ow2.asm:asm:$asmVersion"
+  implementation "org.ow2.asm:asm-commons:$asmVersion"
 
-  compile "io.michaelrocks:grip:$gripVersion"
+  implementation "io.michaelrocks:grip:$gripVersion"
 }
 
 publishing {

--- a/smuggler-plugin/build.gradle
+++ b/smuggler-plugin/build.gradle
@@ -14,15 +14,15 @@ targetCompatibility = JavaVersion.VERSION_1_6
 sourceCompatibility = JavaVersion.VERSION_1_6
 
 dependencies {
-  compile project(":smuggler-compiler")
+  implementation project(":smuggler-compiler")
 
-  compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
-  compile "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
+  implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+  implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
 
   compileOnly "com.android.tools.build:gradle:$androidToolsVersion"
   compileOnly "com.android.tools.build:gradle-api:$androidToolsVersion"
 
-  compile gradleApi()
+  implementation gradleApi()
 }
 
 def GIT_HASH = "git rev-parse HEAD".execute([], project.rootDir).text.trim()

--- a/smuggler-plugin/src/main/java/io/mironov/smuggler/plugin/SmugglerPlugin.kt
+++ b/smuggler-plugin/src/main/java/io/mironov/smuggler/plugin/SmugglerPlugin.kt
@@ -21,9 +21,9 @@ open class SmugglerPlugin : Plugin<Project> {
   }
 
   private fun onPrepareDependencies(project: Project) {
-    project.dependencies.add("compile", "io.mironov.smuggler:smuggler-runtime:${BuildConfig.VERSION}@aar")
-    project.dependencies.add("androidTestCompile", "io.mironov.smuggler:smuggler-runtime:${BuildConfig.VERSION}@aar")
-    project.dependencies.add("testCompile", "io.mironov.smuggler:smuggler-runtime:${BuildConfig.VERSION}@aar")
+    project.dependencies.add("implementation", "io.mironov.smuggler:smuggler-runtime:${BuildConfig.VERSION}@aar")
+    project.dependencies.add("androidTestImplementation", "io.mironov.smuggler:smuggler-runtime:${BuildConfig.VERSION}@aar")
+    project.dependencies.add("testImplementation", "io.mironov.smuggler:smuggler-runtime:${BuildConfig.VERSION}@aar")
   }
 
   private fun onPrepareTransforms(project: Project) {

--- a/smuggler-runtime/build.gradle
+++ b/smuggler-runtime/build.gradle
@@ -21,7 +21,7 @@ android {
 }
 
 dependencies {
-  compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+  implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 }
 
 bintray {

--- a/smuggler-samples/smuggler-application/build.gradle
+++ b/smuggler-samples/smuggler-application/build.gradle
@@ -36,12 +36,12 @@ android {
 }
 
 dependencies {
-  compile project(":smuggler-samples:smuggler-library")
+  implementation project(":smuggler-samples:smuggler-library")
 
-  compile "com.android.support:support-v13:$supportVersion"
-  compile "com.android.support:appcompat-v7:$supportVersion"
-  compile "com.android.support:design:$supportVersion"
+  implementation "com.android.support:support-v13:$supportVersion"
+  implementation "com.android.support:appcompat-v7:$supportVersion"
+  implementation "com.android.support:design:$supportVersion"
 
-  compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
-  compile "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
+  implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+  implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
 }

--- a/smuggler-samples/smuggler-library/build.gradle
+++ b/smuggler-samples/smuggler-library/build.gradle
@@ -20,6 +20,6 @@ android {
 }
 
 dependencies {
-  compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
-  compile "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
+  implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+  implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
 }

--- a/smuggler-samples/smuggler-tests/build.gradle
+++ b/smuggler-samples/smuggler-tests/build.gradle
@@ -26,11 +26,11 @@ android {
 }
 
 dependencies {
-  compile project(":smuggler-samples:smuggler-library")
+  implementation project(":smuggler-samples:smuggler-library")
 
-  compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
-  compile "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
+  implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+  implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
 
-  androidTestCompile "com.android.support.test:runner:$supportTestRunnerVersion"
-  androidTestCompile "com.android.support.test:rules:$supportTestRunnerVersion"
+  androidTestImplementation "com.android.support.test:runner:$supportTestRunnerVersion"
+  androidTestImplementation "com.android.support.test:rules:$supportTestRunnerVersion"
 }


### PR DESCRIPTION
https://docs.gradle.org/4.5.1/userguide/java_library_plugin.html
https://blog.gradle.org/incremental-compiler-avoidance
https://developer.android.com/studio/build/gradle-plugin-3-0-0-migration.html#new_configurations

```
$ ./gradlew clean :smuggler-plugin:generateBuildClass :smuggler-runtime:assembleRelease :smuggler-compiler:assemble :smuggler-samples:smuggler-tests:assembleRelease :sggler-samples:smuggler-application:assembleRelease :smuggler-samples:smuggler-library:assembleRelease

...

> Configure project :smuggler-runtime
Configuration 'compile' in project ':smuggler-runtime' is deprecated. Use 'implementation' instead.
The CompileOptions.bootClasspath property has been deprecated and is scheduled to be removed in Gradle 5.0. Please use the CompileOptions.bootstrapClasspath property instead.

> Configure project :smuggler-samples:smuggler-application
Configuration 'compile' in project ':smuggler-samples:smuggler-application' is deprecated. Use 'implementation' instead.
Configuration 'androidTestCompile' in project ':smuggler-samples:smuggler-application' is deprecated. Use 'androidTestImplementation' instead.
Configuration 'testCompile' in project ':smuggler-samples:smuggler-application' is deprecated. Use 'testImplementation' instead.

> Configure project :smuggler-samples:smuggler-library
Configuration 'compile' in project ':smuggler-samples:smuggler-library' is deprecated. Use 'implementation' instead.
Configuration 'androidTestCompile' in project ':smuggler-samples:smuggler-library' is deprecated. Use 'androidTestImplementation' instead.
Configuration 'testCompile' in project ':smuggler-samples:smuggler-library' is deprecated. Use 'testImplementation' instead.

> Configure project :smuggler-samples:smuggler-tests
Configuration 'compile' in project ':smuggler-samples:smuggler-tests' is deprecated. Use 'implementation' instead.
Configuration 'androidTestCompile' in project ':smuggler-samples:smuggler-tests' is deprecated. Use 'androidTestImplementation' instead.
Configuration 'testCompile' in project ':smuggler-samples:smuggler-tests' is deprecated. Use 'testImplementation' instead.
```