### PR TITLE
Change main runtime configuration to api

### DIFF
--- a/smuggler-plugin/src/main/java/io/mironov/smuggler/plugin/SmugglerPlugin.kt
+++ b/smuggler-plugin/src/main/java/io/mironov/smuggler/plugin/SmugglerPlugin.kt
@@ -30,7 +30,7 @@ open class SmugglerPlugin : Plugin<Project> {
   }
 
   private fun onPrepareDependencies(project: Project) {
-    project.dependencies.add("implementation", "io.mironov.smuggler:smuggler-runtime:${BuildConfig.VERSION}@aar")
+    project.dependencies.add("api", "io.mironov.smuggler:smuggler-runtime:${BuildConfig.VERSION}@aar")
     project.dependencies.add("androidTestImplementation", "io.mironov.smuggler:smuggler-runtime:${BuildConfig.VERSION}@aar")
     project.dependencies.add("testImplementation", "io.mironov.smuggler:smuggler-runtime:${BuildConfig.VERSION}@aar")
   }


### PR DESCRIPTION
When run in a project whose app module depends on a library module and _only_ the library module contains the AutoParcelable subtypes, the app module will fail to compile unless the smuggler-runtime is added to the library module as an api dependency, allowing the runtime to be exposed to the library's consumers.  

Anyone who consumes v0.13.0 and doesn't apply the plugin to all modules referring to the AutoParcelable subtype will be broken. 😞

Unfortunately, building each of the modules under smuggler-samples did not surface this issue with [this change](https://github.com/nsk-mironov/smuggler/pull/33/files#diff-ff5d8f9191a689fda337e458dda129be), since each module directly applies the plugin.  My bad.